### PR TITLE
[AC/MoneyCoop] Ajout du paramètre seuil_credit pour les achats

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -34,3 +34,6 @@ pChart_path = ../libs/pChart
 ; path to PHPMailer seen from the source/ folder
 PHPMailer_path = ../libs/phpmailer
 
+[MoneyCoop]
+; seuil du crédit fixé par le Gase
+seuil_credit = 20

--- a/source/achats.php
+++ b/source/achats.php
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
+        <link rel="stylesheet" href="style_default.css" />
 		<title>ACHATS</title>
     </head>
     <body>

--- a/source/fonctions_bd_gase.php
+++ b/source/fonctions_bd_gase.php
@@ -12,6 +12,7 @@ define ("GASE_CONFIG_FILE_PATH", "../config.ini");
  *  - dans les fonctions, appeler la connexion avec `global $mysql`
  *  - remplacer $connection par $mysql pour les query()
  *  - remplacer fetch_array() par fetch() car différent avec PDO
+ *  - remplacer insert_id par lastInsertId()
  * TODO: la prochaine étape sera d'encapsuler tout ça dans une classe pour
  * ne pas avoir à utiliser de variable globale
  */
@@ -32,7 +33,7 @@ function EnregistrerAchatAdherent($idAdherent, $montantTTC, $nbArticles){
 	global $mysql;
 
 	$mysql->query("INSERT INTO _inde_ACHATS (DATE_ACHAT,ID_ADHERENT,TOTAL_TTC,NB_REFERENCES) values(NOW(),'$idAdherent','$montantTTC','$nbArticles')");
-	$idCommande = $mysql->insert_id;
+	$idCommande = $mysql->lastInsertId();
 	
 	return $idCommande;
 }

--- a/source/inde_fonctionsAD.php
+++ b/source/inde_fonctionsAD.php
@@ -114,6 +114,7 @@
 		global $mysql;
 		$compteur = 0;
 		$result = $mysql->query("SELECT c.ID_ACHAT, c.TOTAL_TTC, c.NB_REFERENCES, c.DATE_ACHAT FROM _inde_ACHATS c WHERE c.ID_ADHERENT = '$idAdherent' ORDER BY c.DATE_ACHAT DESC");
+		$listeCde = [];
 		while ( $row = $result->fetch())
 		{		
 			$ligne['ID_ACHATS'] = $row[0];

--- a/source/inde_fonctionsMC.php
+++ b/source/inde_fonctionsMC.php
@@ -21,6 +21,7 @@
 	{
 		global $mysql;
 		$result = $mysql->query("SELECT MONTANT,DATE FROM _inde_COMPTES WHERE ID_ADHERENT='$idAdherent' AND OPERATION = 'APPROVISIONNEMENT' UNION SELECT -MONTANT,DATE FROM _inde_COMPTES WHERE ID_ADHERENT='$idAdherent' AND OPERATION = 'DEPENSE' ORDER BY 2 DESC ");
+		$tabVersements = [];
 		while ( $row = $result->fetch())
 		{
 			$tabVersements[$row["DATE"]] = $row["MONTANT"];


### PR DESCRIPTION
et quelques corrections liées au changement de connexion MySQL...

Modifier le paramètre `seuil_credit` dans la section `[MoneyCoop]` du fichier **config.ini** afin de permettre (ou non) la possibilité au gasier de faire un achat en dépassant sont solde dans la limite du seuil fixé (par défaut c'est 20 €)
